### PR TITLE
Fix issue 9 (travis build was failing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,7 @@ addons:
 # go faster on travis
 sudo: false
 
+# stop mvn install from running
+install: true
+
 script: mvn -B -V package javadoc:javadoc test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
     - openjdk7
-    - openjdk8
     - oraclejdk7
     - oraclejdk8
 addons:
@@ -9,3 +8,5 @@ addons:
 
 # go faster on travis
 sudo: false
+
+script: mvn -B -V package javadoc:javadoc test


### PR DESCRIPTION
Now we don't include openjdk8 (it doesn't exist), and include
a test command that can work on any machine.