### PR TITLE
ERROR: schema "ztest_schema1" already exists error solved when reruning integration tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,7 @@
                                     <driver>org.postgresql.Driver</driver>
                                     <url>jdbc:postgresql://${test.db.host}:${test.db.port}/${test.db.name1}</url>
                                     <sqlCommand>
+                                        DROP EXTENSION IF EXISTS hstore CASCADE;
                                         CREATE EXTENSION hstore;
                                         DROP SCHEMA IF EXISTS ztest_schema1 CASCADE;
                                         DROP SCHEMA IF EXISTS ztest_schema2 CASCADE;
@@ -368,6 +369,7 @@
                                     <driver>org.postgresql.Driver</driver>
                                     <url>jdbc:postgresql://${test.db.host}:${test.db.port}/${test.db.name2}</url>
                                     <sqlCommand>
+                                        DROP EXTENSION IF EXISTS hstore CASCADE;
                                         CREATE EXTENSION hstore;
                                         DROP SCHEMA IF EXISTS ztest_schema1 CASCADE;
                                     </sqlCommand>


### PR DESCRIPTION
After the first execution of integration tests, i faced with ERROR: schema "ztest_schema1" already exists.

By adding "DROP EXTENSION IF EXISTS hstore CASCADE;" before creating hstore extension, this problem solved for me. (I think because of failure on creating existing hstore extension this error propagates!)
If it is a case, by this pull request the problem will be solved.