### PR TITLE
Change cast to unwrap and ParameterizedRowMapper to RowMapper.

### DIFF
--- a/src/main/java/de/zalando/typemapper/core/TypeMapper.java
+++ b/src/main/java/de/zalando/typemapper/core/TypeMapper.java
@@ -15,7 +15,7 @@ import org.postgresql.util.PGobject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.jdbc.core.simple.ParameterizedRowMapper;
+import org.springframework.jdbc.core.RowMapper;
 
 import de.zalando.typemapper.core.db.DbFunction;
 import de.zalando.typemapper.core.db.DbFunctionRegister;
@@ -32,7 +32,7 @@ import de.zalando.typemapper.core.result.SimpleResultNode;
 import de.zalando.typemapper.parser.exception.RowParserException;
 import de.zalando.typemapper.parser.postgres.ParseUtils;
 
-public class TypeMapper<ITEM> implements ParameterizedRowMapper<ITEM> {
+public class TypeMapper<ITEM> implements RowMapper<ITEM> {
 
     private static final Logger LOG = LoggerFactory.getLogger(TypeMapper.class);
 

--- a/src/main/java/de/zalando/typemapper/core/TypeMapper.java
+++ b/src/main/java/de/zalando/typemapper/core/TypeMapper.java
@@ -76,7 +76,7 @@ public class TypeMapper<ITEM> implements ParameterizedRowMapper<ITEM> {
         LOG.trace("Extracting result tree");
 
         // cast to obtain more information from the result set.
-        final Jdbc4ResultSet pgSet = (Jdbc4ResultSet) set;
+        final Jdbc4ResultSet pgSet = set.unwrap(Jdbc4ResultSet.class);
         final ResultSetMetaData rsMetaData = pgSet.getMetaData();
 
         final ResultTree tree = new ResultTree();

--- a/src/main/java/de/zalando/typemapper/core/fieldMapper/FieldMapperRegister.java
+++ b/src/main/java/de/zalando/typemapper/core/fieldMapper/FieldMapperRegister.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 
 import java.util.Date;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import de.zalando.typemapper.core.ValueTransformer;
@@ -62,6 +63,9 @@ public class FieldMapperRegister {
 
         final FieldMapper hstoreMapper = new HStoreFieldMapper();
         FieldMapperRegister.register(Map.class, hstoreMapper);
+
+        final FieldMapper uuidMapper = new UUIDFieldMapper();
+        FieldMapperRegister.register(UUID.class, uuidMapper);
     }
 
     @SuppressWarnings("rawtypes")

--- a/src/main/java/de/zalando/typemapper/core/fieldMapper/UUIDFieldMapper.java
+++ b/src/main/java/de/zalando/typemapper/core/fieldMapper/UUIDFieldMapper.java
@@ -1,0 +1,28 @@
+package de.zalando.typemapper.core.fieldMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+/**
+ * Created by akushsky on 27.08.2015.
+ */
+public class UUIDFieldMapper implements FieldMapper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UUIDFieldMapper.class);
+
+    @Override
+    public Object mapField(String string, Class<?> clazz) {
+        if (string == null) {
+            return null;
+        }
+
+        try {
+            return UUID.fromString(string);
+        } catch (IllegalArgumentException e) {
+            LOG.error("Could not convert {} to UUID.", string);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
If using some sort of pool libraries (like c3p0 or HikariCP) - got ClassCastException, but unwrap always working good.

So, ParameterizedRowMapper is deprecated for now and removed from latest Spring version.
RowMapper is a legal placeholder of ParameterizedRowMapper since Spring 3.0